### PR TITLE
Add missing contact id to fix in-page "CONTACT" link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -109,7 +109,7 @@
     <!-- More Info Section -->
     <footer>
       <article class="footer_column">
-        <h3 style="text-transform: uppercase;">Contact</h3>
+        <h3 id="contact" style="text-transform: uppercase;">Contact</h3>
         <p>Use GitHub's <a href="https://github.com/usc-imi/aeo-light/issues">issue tracker service</a> to submit feedback on the program.</p>
         <p>For more information about the AEO-Light project, contact Greg Wilsbacher at <a href="mailto:gregw@mailbox.sc.edu">gregw@mailbox.sc.edu</a></p>
       </article>


### PR DESCRIPTION
Small fix to allow the "CONTACT" in-page navigation link to scroll to the appropriate section.